### PR TITLE
Allow an override file in root of project

### DIFF
--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -23,6 +23,6 @@ server {
         sub_filter ${APP_URL} ${SHARED_URL};
         sub_filter_once off;
     }
-    
-    include /var/www/nginx.overrides.conf;
+
+    include /var/www/*.nginx.conf;  
 }


### PR DESCRIPTION
Allows us to override things like `client_max_body_size` and other things that may vary on different projects