### PR TITLE
change xdebug profiling output folder

### DIFF
--- a/resources/config/php/xdebug-profiling.ini
+++ b/resources/config/php/xdebug-profiling.ini
@@ -3,4 +3,4 @@ xdebug.mode=develop,debug,profile
 xdebug.client_host=host.docker.internal
 xdebug.start_with_request=yes
 xdebug.log=/tmp/xdebug.log
-xdebug.output_dir=/var/www/xdebug
+xdebug.output_dir=/var/www/profiling


### PR DESCRIPTION
When we install the XDebug extension - if an XDebug folder is present it blows up.

This works around that by changing the xdebug profiling folder to `profiling` to avoid the name conflict.