### PR TITLE
Only run entry point scripts when the container first starts

### DIFF
--- a/resources/scripts/php/entrypoint.sh
+++ b/resources/scripts/php/entrypoint.sh
@@ -4,23 +4,43 @@ echo 'Container entrypoint'
 echo "Running as: $(whoami)"
 
 if [ -f '/docker-scripts/root-start-script.sh' ]; then
-    echo 'Found root-start-script.sh to run'
-    sudo -E /docker-scripts/root-start-script.sh
+    if [ -f '/docker-scripts/ran-root-start-script' ]; then
+        echo 'Skipping root-start-script.sh'
+    else
+        echo 'Found root-start-script.sh to run'
+        sudo -E /docker-scripts/root-start-script.sh
+        sudo -E touch '/docker-scripts/ran-root-start-script'
+    fi
 fi
 
 if [ -f '/docker-scripts/custom-root-script.sh' ]; then
-    echo 'Found custom-root-script.sh to run'
-    sudo -E /docker-scripts/custom-root-script.sh
+    if [ -f '/docker-scripts/ran-custom-root-script' ]; then
+        echo 'Skipping custom-root-script.sh'
+    else
+        echo 'Found custom-root-script.sh to run'
+        sudo -E /docker-scripts/custom-root-script.sh
+        sudo -E touch '/docker-scripts/ran-custom-root-script'
+    fi
 fi
 
 if [ -f '/docker-scripts/www-start-script.sh' ]; then
-    echo 'Found www-start-script.sh to run'
-    /docker-scripts/www-start-script.sh
+    if [ -f '/docker-scripts/ran-www-start-script' ]; then
+        echo 'Skipping www-start-script.sh'
+    else
+        echo 'Found www-start-script.sh to run'
+        /docker-scripts/www-start-script.sh
+        sudo -E touch '/docker-scripts/ran-www-start-script'
+    fi
 fi
 
 if [ -f '/docker-scripts/custom-www-script.sh' ]; then
-    echo 'Found custom-www-script.sh to run'
-    /docker-scripts/custom-www-script.sh
+    if [ -f '/docker-scripts/ran-custom-www-script' ]; then
+        echo 'Skipping custom-www-script.sh'
+    else
+        echo 'Found custom-www-script.sh to run'
+        /docker-scripts/custom-www-script.sh
+        sudo -E touch '/docker-scripts/ran-custom-www-script'
+    fi
 fi
 
 echo "Running command exec $*"


### PR DESCRIPTION
There is a difference between volker down and volker stop, down also deletes the containers.
Right now when you do volker stop and then volker up, the initial entrypoint scripts are run again - reinstalling and setting up things afresh.

I think we should only do this the first time so you need to volker down and volker up to re-run the entrypoint scripts installs.

This will enable the volker stop -> volker up to be a must faster restart mechanism

Tested the changes locally, here's the log

![image](https://user-images.githubusercontent.com/61095076/172402404-bdf8ca7d-4f69-4609-90b5-58ba12eef582.png)
