### PR TITLE
Fix Nginx config generation

### DIFF
--- a/resources/scripts/nginx/entrypoint.sh
+++ b/resources/scripts/nginx/entrypoint.sh
@@ -21,7 +21,8 @@ fi
 
 # Generate the Nginx configuration using the configuration script
 echo 'Generating Nginx Configuration';
-sh /docker-scripts/generate-config.sh > /etc/nginx/conf.d/app.conf
+sh /docker-scripts/generate-config.sh > /root/app.conf
+mv /root/app.conf /etc/nginx/conf.d/app.conf
 echo 'Done';
 
 echo 'Signalling Reload to Nginx..'


### PR DESCRIPTION
Occasionally Nginx will fail to start due to syntax errors.

I think this was actually a race condition where nginx was still starting and the config file was being written to at the same time.

To combat this i've changed it to write the config file to a temporary file and then move it so it's always 100% generated